### PR TITLE
fix(evm): correct chain ID extraction and configuration for compatibility tests

### DIFF
--- a/evmd/cmd/evmd/cmd/root.go
+++ b/evmd/cmd/evmd/cmd/root.go
@@ -152,17 +152,18 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
-			var evmChainID uint64 = evmdconfig.EpixMainnetChainID // default
+			// Initialize with default EVM chain ID
+			var evmChainID uint64 = evmdconfig.EpixMainnetChainID
 
-			chainIDFromCtx := initClientCtx.ChainID
-
-			// If not available in context, try to get it from command flags
-			if chainIDFromCtx == "" {
-				if chainIDFlag := cmd.Flag("chain-id"); chainIDFlag != nil && chainIDFlag.Value.String() != "" {
-					chainIDFromCtx = chainIDFlag.Value.String()
-				}
+			// Try to get chain ID from command flag or context
+			chainIDFromCtx := ""
+			if chainIDFlag := cmd.Flag("chain-id"); chainIDFlag != nil && chainIDFlag.Value.String() != "" {
+				chainIDFromCtx = chainIDFlag.Value.String()
+			} else if initClientCtx.ChainID != "" {
+				chainIDFromCtx = initClientCtx.ChainID
 			}
 
+			// Extract EVM chain ID from the chain ID if available
 			if chainIDFromCtx != "" {
 				evmChainID = extractEVMChainID(chainIDFromCtx)
 			}

--- a/proposals/v0.5.1-upgrade-proposal.json
+++ b/proposals/v0.5.1-upgrade-proposal.json
@@ -1,0 +1,18 @@
+{
+  "messages": [
+    {
+      "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+      "authority": "epix10d07y265gmmuvt4z0w9aw880jnsr700j0fas3g",
+      "plan": {
+        "name": "v0.5.1",
+        "height": "1612500",
+        "info": "https://github.com/EpixZone/EpixChain/releases/tag/v0.5.1"
+      }
+    }
+  ],
+  "metadata": "EpixChain v0.5.1 Upgrade Proposal",
+  "deposit": "5000000000000000000000aepix",
+  "title": "Upgrade EpixChain to v0.5.1 (Expedited)",
+  "summary": "This expedited upgrade migrates EpixChain to v0.5.1.\n\nKey changes:\n- Enhanced denom metadata for aepix/epix tokens\n- Improved EVM configuration handling\n- Updated function signatures for better compatibility\n\nRelease: https://github.com/EpixZone/EpixChain/releases/tag/v0.5.1\n\nBinary verification:\n- Build from source: `git checkout v0.5.1 && make install`\n- Verify version: `epixd version` should show `v0.5.1`",
+  "expedited": true
+}

--- a/tests/evm-tools-compatibility/viem/.env
+++ b/tests/evm-tools-compatibility/viem/.env
@@ -1,2 +1,5 @@
 # Chain configuration
+# EVM Chain ID for viem client (must match the node's EVM chain ID)
+# The node will be started with cosmos chain-id "test_262144-1" which extracts to EVM chain ID 262144
+CHAIN_ID=262144
 PRIVATE_KEY=0x8a36c69d940a92fcea94b36d0f2928c7a0ee19a90073eda769693298dfa9603b

--- a/tests/evm-tools-compatibility/viem/test/viemFunctions.test.js
+++ b/tests/evm-tools-compatibility/viem/test/viemFunctions.test.js
@@ -9,7 +9,7 @@ const { expect } = require("chai");
 const tokenArtifact = require("./contractABI/TokenExample.json");
 
 require("dotenv").config();
-const chainId = process.env.CHAIN_ID || 262144; // Default to 262144 if not set
+const chainId = process.env.CHAIN_ID ? parseInt(process.env.CHAIN_ID, 10) : 262144; // Default to 262144 if not set
 
 describe("Viem Full Feature Test", function () {
   let publicClient,

--- a/tests/solidity/test-helper.js
+++ b/tests/solidity/test-helper.js
@@ -316,9 +316,17 @@ function setupNetwork ({ runConfig, timeout }) {
     const rootDir = path.resolve(__dirname, '..', '..');     // → ".../evm"
     const scriptPath = path.join(rootDir, 'scripts', 'local_node.sh');  // → ".../evm/scripts/local_node.sh"
 
+    // Extract chain ID from Go config to set CHAIN_ID environment variable
+    const goConfigPath = path.join(rootDir, 'server', 'config', 'config.go')
+    const evmChainId = extractChainIDFromGo(goConfigPath)
+    const cosmosChainId = `test_${evmChainId}-1`
+
+    logger.info(`Setting CHAIN_ID=${cosmosChainId} for local_node.sh`)
+
     const osdProc = spawn(scriptPath, ['-y'], {
       cwd: rootDir,
       stdio: ['ignore', 'pipe', 'pipe'],  // <-- stdout/stderr streams
+      env: { ...process.env, CHAIN_ID: cosmosChainId }  // Pass CHAIN_ID to local_node.sh
     })
 
     logger.info(`Starting epixd process... timeout: ${timeout}ms`)


### PR DESCRIPTION
This pull request focuses on improving the handling and extraction of EVM chain IDs throughout the codebase and scripts, particularly to ensure compatibility between the Cosmos chain ID and EVM tooling (like viem). It also introduces a new upgrade proposal for EpixChain v0.5.1. The changes aim to make the chain ID handling more robust and less error-prone, especially in local development and testing environments.

**Chain ID Extraction and EVM Compatibility Improvements:**

* Refactored the logic in `evmd/cmd/evmd/cmd/root.go` to prioritize extracting the EVM chain ID from the command flag or context, ensuring that the correct EVM chain ID is set even if the Cosmos chain ID format varies.
* Updated `scripts/local_node.sh` to delay setting the client chain ID until after `epixd init`, preventing the default EVM chain ID from overwriting the intended value, and added explicit extraction of the EVM chain ID from the Cosmos chain ID with robust fallback logic. The extracted EVM chain ID is now passed directly to the node startup command. [[1]](diffhunk://#diff-e13b53c305d431aa7f52ef861eea94f0a4e87e7ac2b4b58cb0ecfc031e7cffebL174-R177) [[2]](diffhunk://#diff-e13b53c305d431aa7f52ef861eea94f0a4e87e7ac2b4b58cb0ecfc031e7cffebR235-R238) [[3]](diffhunk://#diff-e13b53c305d431aa7f52ef861eea94f0a4e87e7ac2b4b58cb0ecfc031e7cffebR347-R366)
* Enhanced `scripts/tests_compatibility_viem.sh` to source the `.env` file early, convert the numeric `CHAIN_ID` to the correct Cosmos chain ID format for node startup, and restore the numeric value for viem tests, ensuring seamless compatibility between the node and EVM tooling. [[1]](diffhunk://#diff-7aae1da588f9735300913c05c040092d4aa031f2ee8257ffe0a07c76475a2439R39-R69) [[2]](diffhunk://#diff-7aae1da588f9735300913c05c040092d4aa031f2ee8257ffe0a07c76475a2439L54-L63)
* Updated the `.env` and test files in `tests/evm-tools-compatibility/viem` to clarify and enforce the correct EVM chain ID usage, and improved parsing in the test script to ensure the chain ID is always numeric. [[1]](diffhunk://#diff-31cd0b88d503097b3846b7b1f4f4a75052140d19ec82db736c18dac9a35406f8R2-R4) [[2]](diffhunk://#diff-9fa2c7678385bb99ccba877d0eac45e7fe8a0eaea01869cb3f341e02d1c89984L12-R12)

**Governance and Upgrade:**

* Added a new upgrade proposal file `proposals/v0.5.1-upgrade-proposal.json` for EpixChain v0.5.1, detailing the expedited upgrade, key changes, and instructions for binary verification.