### PR TITLE
Release/v0.5.1

### DIFF
--- a/evmd/constants.go
+++ b/evmd/constants.go
@@ -1,0 +1,33 @@
+package evmd
+
+import (
+	erc20types "github.com/cosmos/evm/x/erc20/types"
+)
+
+// Chain denomination constants for EpixChain
+const (
+	// BaseDenom is the base denomination for the EpixChain (atto-epix)
+	BaseDenom = "aepix"
+
+	// DisplayDenom is the display denomination for the EpixChain
+	DisplayDenom = "epix"
+
+	// Decimals is the number of decimals for the display denomination
+	Decimals = 18
+
+	// WEPIXContract is the WEPIX contract address
+	WEPIXContract = "0xD4949664cD82660AaE99bEdc034a0deA8A0bd517"
+)
+
+var (
+	// TokenPairs creates a slice of token pairs for the native denom of EpixChain
+	TokenPairs = []erc20types.TokenPair{
+		{
+			Erc20Address:  WEPIXContract,
+			Denom:         BaseDenom,
+			Enabled:       true,
+			ContractOwner: erc20types.OWNER_MODULE,
+		},
+	}
+)
+

--- a/evmd/genesis.go
+++ b/evmd/genesis.go
@@ -30,6 +30,10 @@ type GenesisState map[string]json.RawMessage
 func NewEVMGenesisState() *evmtypes.GenesisState {
 	evmGenState := evmtypes.DefaultGenesisState()
 	evmGenState.Params.ActiveStaticPrecompiles = evmtypes.AvailableStaticPrecompiles
+	evmGenState.Params.EvmDenom = testconstants.ExampleAttoDenom
+	evmGenState.Params.ExtendedDenomOptions = &evmtypes.ExtendedDenomOptions{
+		ExtendedDenom: testconstants.ExampleAttoDenom,
+	}
 	evmGenState.Preinstalls = evmtypes.DefaultPreinstalls
 
 	return evmGenState

--- a/evmd/genesis.go
+++ b/evmd/genesis.go
@@ -3,7 +3,6 @@ package evmd
 import (
 	"encoding/json"
 
-	testconstants "github.com/cosmos/evm/testutil/constants"
 	epixminttypes "github.com/cosmos/evm/x/epixmint/types"
 	erc20types "github.com/cosmos/evm/x/erc20/types"
 	feemarkettypes "github.com/cosmos/evm/x/feemarket/types"
@@ -30,9 +29,9 @@ type GenesisState map[string]json.RawMessage
 func NewEVMGenesisState() *evmtypes.GenesisState {
 	evmGenState := evmtypes.DefaultGenesisState()
 	evmGenState.Params.ActiveStaticPrecompiles = evmtypes.AvailableStaticPrecompiles
-	evmGenState.Params.EvmDenom = testconstants.ExampleAttoDenom
+	evmGenState.Params.EvmDenom = BaseDenom
 	evmGenState.Params.ExtendedDenomOptions = &evmtypes.ExtendedDenomOptions{
-		ExtendedDenom: testconstants.ExampleAttoDenom,
+		ExtendedDenom: BaseDenom,
 	}
 	evmGenState.Preinstalls = evmtypes.DefaultPreinstalls
 
@@ -42,11 +41,11 @@ func NewEVMGenesisState() *evmtypes.GenesisState {
 // NewErc20GenesisState returns the default genesis state for the ERC20 module.
 //
 // NOTE: for the example chain implementation we are also adding a default token pair,
-// which is the base denomination of the chain (i.e. the WEVMOS contract).
+// which is the base denomination of the chain (i.e. the WEPIX contract).
 func NewErc20GenesisState() *erc20types.GenesisState {
 	erc20GenState := erc20types.DefaultGenesisState()
-	erc20GenState.TokenPairs = testconstants.ExampleTokenPairs
-	erc20GenState.NativePrecompiles = []string{testconstants.WEVMOSContractMainnet}
+	erc20GenState.TokenPairs = TokenPairs
+	erc20GenState.NativePrecompiles = []string{WEPIXContract}
 
 	return erc20GenState
 }
@@ -60,7 +59,7 @@ func NewMintGenesisState() *minttypes.GenesisState {
 
 	// Set Epix-specific minting parameters
 	// Initial inflation: 10.527 billion EPIX per year / 42 billion max supply = ~25.06%
-	mintGenState.Params.MintDenom = testconstants.ExampleAttoDenom
+	mintGenState.Params.MintDenom = BaseDenom
 	mintGenState.Params.InflationRateChange = math.LegacyMustNewDecFromStr("0.130000000000000000") // 13% max annual change
 	mintGenState.Params.InflationMax = math.LegacyMustNewDecFromStr("1.000000000000000000")        // 100% max (42B max supply)
 	mintGenState.Params.InflationMin = math.LegacyMustNewDecFromStr("0.070000000000000000")        // 7% minimum
@@ -105,23 +104,23 @@ func NewBankGenesisState() *banktypes.GenesisState {
 	// Add metadata for aepix/epix denominations
 	epixMetadata := banktypes.Metadata{
 		Description: "The native staking and governance token of the EpixChain",
-		Base:        testconstants.ExampleAttoDenom, // "aepix"
+		Base:        BaseDenom,
 		// NOTE: Denom units MUST be increasing by exponent
 		DenomUnits: []*banktypes.DenomUnit{
 			{
-				Denom:    testconstants.ExampleAttoDenom, // "aepix"
+				Denom:    BaseDenom,
 				Exponent: 0,
-				Aliases:  []string{"aepix"},
+				Aliases:  []string{BaseDenom},
 			},
 			{
-				Denom:    testconstants.ExampleDisplayDenom, // "epix"
-				Exponent: 18,
-				Aliases:  []string{"epix"},
+				Denom:    DisplayDenom,
+				Exponent: Decimals,
+				Aliases:  []string{DisplayDenom},
 			},
 		},
 		Name:    "EpixChain",
 		Symbol:  "EPIX",
-		Display: testconstants.ExampleDisplayDenom, // "epix"
+		Display: DisplayDenom,
 	}
 
 	bankGenState.DenomMetadata = []banktypes.Metadata{epixMetadata}

--- a/evmd/upgrades.go
+++ b/evmd/upgrades.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
-	testconstants "github.com/cosmos/evm/testutil/constants"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 )
 
@@ -35,18 +34,18 @@ func (app EVMD) RegisterUpgradeHandlers() {
 				Description: "The native staking and governance token of the EpixChain",
 				DenomUnits: []*banktypes.DenomUnit{
 					{
-						Denom:    "aepix",
+						Denom:    BaseDenom,
 						Exponent: 0,
 						Aliases:  nil,
 					},
 					{
-						Denom:    "epix",
-						Exponent: 18,
+						Denom:    DisplayDenom,
+						Exponent: Decimals,
 						Aliases:  nil,
 					},
 				},
-				Base:    "aepix",
-				Display: "epix",
+				Base:    BaseDenom,
+				Display: DisplayDenom,
 				Name:    "EpixChain",
 				Symbol:  "EPIX",
 				URI:     "https://epix.zone/",
@@ -56,9 +55,9 @@ func (app EVMD) RegisterUpgradeHandlers() {
 
 			// Update EVM params to set the EvmDenom and ExtendedDenomOptions
 			evmParams := app.EVMKeeper.GetParams(sdkCtx)
-			evmParams.EvmDenom = testconstants.ExampleAttoDenom // "aepix"
+			evmParams.EvmDenom = BaseDenom
 			evmParams.ExtendedDenomOptions = &evmtypes.ExtendedDenomOptions{
-				ExtendedDenom: testconstants.ExampleAttoDenom, // "aepix"
+				ExtendedDenom: BaseDenom,
 			}
 			if err := app.EVMKeeper.SetParams(sdkCtx, evmParams); err != nil {
 				return nil, err

--- a/proposals/v0.5.1-upgrade-proposal.json
+++ b/proposals/v0.5.1-upgrade-proposal.json
@@ -5,14 +5,13 @@
       "authority": "epix10d07y265gmmuvt4z0w9aw880jnsr700j0fas3g",
       "plan": {
         "name": "v0.5.1",
-        "height": "1612500",
+        "height": "1550000",
         "info": "https://github.com/EpixZone/EpixChain/releases/tag/v0.5.1"
       }
     }
   ],
   "metadata": "EpixChain v0.5.1 Upgrade Proposal",
   "deposit": "5000000000000000000000aepix",
-  "title": "Upgrade EpixChain to v0.5.1 (Expedited)",
-  "summary": "This expedited upgrade migrates EpixChain to v0.5.1.\n\nKey changes:\n- Enhanced denom metadata for aepix/epix tokens\n- Improved EVM configuration handling\n- Updated function signatures for better compatibility\n\nRelease: https://github.com/EpixZone/EpixChain/releases/tag/v0.5.1\n\nBinary verification:\n- Build from source: `git checkout v0.5.1 && make install`\n- Verify version: `epixd version` should show `v0.5.1`",
-  "expedited": true
+  "title": "Upgrade EpixChain to v0.5.1",
+  "summary": "This upgrade migrates EpixChain to v0.5.1.\n\nKey changes:\n- Enhanced denom metadata for aepix/epix tokens\n- Improved EVM configuration handling\n- Updated function signatures for better compatibility\n\nRelease: https://github.com/EpixZone/EpixChain/releases/tag/v0.5.1\n\nBinary verification:\n- Build from source: `git checkout v0.5.1 && make install`\n- Verify version: `epixd version` should show `v0.5.1`"
 }


### PR DESCRIPTION
This pull request refactors EpixChain's denomination constants and updates related configuration, genesis, and upgrade logic to use these new constants consistently across the codebase. It removes usage of test constants and centralizes chain-specific values, improving maintainability and reducing errors. Additionally, EVM and ERC20 module initialization and upgrade handlers are updated to properly set and initialize denom metadata and options.

**Denomination and Metadata Refactoring**
* Added new constants for `BaseDenom`, `DisplayDenom`, `Decimals`, and `WEPIXContract` in `evmd/constants.go`, and replaced all previous references to test constants with these new values throughout the codebase.
* Updated bank and mint genesis state creation to use the new denom constants for metadata, mint denom, and display denom. [[1]](diffhunk://#diff-e99c28e51108f39a05c1eac4a13db827d715d0c93f5662759b3f2ffbc98329e0L59-R62) [[2]](diffhunk://#diff-e99c28e51108f39a05c1eac4a13db827d715d0c93f5662759b3f2ffbc98329e0L104-R123)
* Refactored the upgrade handler to update denom metadata and EVM params using the new constants, and ensured EVM coin info is initialized from bank metadata.

**EVM and ERC20 Module Initialization**
* Set `EvmDenom` and `ExtendedDenomOptions` in EVM genesis state and upgrade handler using the new base denom constant. [[1]](diffhunk://#diff-e99c28e51108f39a05c1eac4a13db827d715d0c93f5662759b3f2ffbc98329e0R32-R35) [[2]](diffhunk://#diff-9fe9392146c5e77c6cf780422ef62c1457499d673767d8a8e7e61e10ea1f50f3L35-R72)
* Updated ERC20 genesis state to use the new token pair and contract address constants for the native token.

**Testing and Configuration Updates**
* Removed usage of test constants in the test network setup, using the new denom constants for bond denom, min gas prices, and EVM chain ID extraction. [[1]](diffhunk://#diff-56368b1b954101ea3708d58f25f462b353aedb1614197e2d6edcb76a4a6f7d6eL36) [[2]](diffhunk://#diff-56368b1b954101ea3708d58f25f462b353aedb1614197e2d6edcb76a4a6f7d6eL126-R149) [[3]](diffhunk://#diff-56368b1b954101ea3708d58f25f462b353aedb1614197e2d6edcb76a4a6f7d6eL488-R512)
* Added a utility function to extract the EVM chain ID from the Cosmos chain ID for configuration.

**Proposal Updates**
* Updated the v0.5.1 upgrade proposal JSON to reflect the new upgrade height and removed the expedited flag from the proposal.