### PR TITLE
feat(upgrade): add v0.5.3 upgrade for deterministic emission

### DIFF
--- a/evmd/upgrades.go
+++ b/evmd/upgrades.go
@@ -20,9 +20,10 @@ import (
 // Upgrade names
 const UpgradeName_v0_5_1 = "v0.5.1"
 const UpgradeName_v0_5_2 = "v0.5.2"
+const UpgradeName_v0_5_3 = "v0.5.3"
 
 // UpgradeName is the current upgrade (for store upgrades)
-const UpgradeName = UpgradeName_v0_5_1
+const UpgradeName = UpgradeName_v0_5_3
 
 // RegisterUpgradeHandlers registers upgrade handlers for v0.5.1 and v0.5.2
 func (app EVMD) RegisterUpgradeHandlers() {
@@ -60,13 +61,33 @@ func (app EVMD) RegisterUpgradeHandlers() {
 		},
 	)
 
+	// Register v0.5.3 upgrade handler - Deterministic Emission Fix
+	app.UpgradeKeeper.SetUpgradeHandler(
+		UpgradeName_v0_5_3,
+		func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+			sdkCtx := sdk.UnwrapSDKContext(ctx)
+			sdkCtx.Logger().Info("Starting EpixChain v0.5.3 upgrade - Deterministic Emission Fix...")
+
+			// Log the upgrade details for transparency
+			sdkCtx.Logger().Info("This upgrade fixes a consensus bug in token emission calculations")
+
+			// No state migration needed - the fix is purely in the calculation logic
+			// which will take effect from this block forward
+
+			// Run module migrations
+			return app.ModuleManager.RunMigrations(ctx, app.Configurator(), fromVM)
+		},
+	)
+
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
 	if err != nil {
 		panic(err)
 	}
 
-	// Handle both v0.5.1 and v0.5.2 upgrades
-	if (upgradeInfo.Name == UpgradeName_v0_5_1 || upgradeInfo.Name == UpgradeName_v0_5_2) &&
+	// Handle v0.5.1, v0.5.2, and v0.5.3 upgrades
+	if (upgradeInfo.Name == UpgradeName_v0_5_1 ||
+		upgradeInfo.Name == UpgradeName_v0_5_2 ||
+		upgradeInfo.Name == UpgradeName_v0_5_3) &&
 		!app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
 		storeUpgrades := storetypes.StoreUpgrades{
 			Added: []string{},


### PR DESCRIPTION
This pull request introduces a new upgrade (v0.5.3) to address a consensus bug in token emission calculations and refactors the emission logic to ensure deterministic, architecture-independent results. The most important changes are:

**Upgrade Handling:**

* Added a new upgrade constant `UpgradeName_v0_5_3` and set it as the current upgrade version in `evmd/upgrades.go`.
* Registered a new upgrade handler for v0.5.3 that logs the upgrade and runs module migrations, clarifying that no state migration is needed as the fix is in the calculation logic. The upgrade handler check now includes v0.5.3.

**Deterministic Emission Calculation:**

* Refactored emission rate calculations in `x/epixmint/keeper/emission.go` to use only deterministic `sdkmath.LegacyDec` arithmetic, removing all non-deterministic `math` and `big` operations to ensure consensus across all CPU architectures.
* Implemented a new `approximateDecayWithDec` helper function that deterministically approximates exponentiation for emission decay, using integer arithmetic and linear interpolation for fractional exponents.
* Updated function comments and logic to clarify the deterministic approach and its importance for consensus, and ensured all calculations are performed using the new approach. [[1]](diffhunk://#diff-b59d765e67c3995a80398661546d2a143fee24e631b03006d69735dbefb1dfd5R51) [[2]](diffhunk://#diff-b59d765e67c3995a80398661546d2a143fee24e631b03006d69735dbefb1dfd5L98-R149)# Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
