### PR TITLE
Set height for v0.5.3 upgrade.

### DIFF
--- a/proposals/v0.5.3-upgrade-proposal.json
+++ b/proposals/v0.5.3-upgrade-proposal.json
@@ -5,7 +5,7 @@
       "authority": "epix10d07y265gmmuvt4z0w9aw880jnsr700j0fas3g",
       "plan": {
         "name": "v0.5.3",
-        "height": "REPLACE_WITH_UPGRADE_HEIGHT_AFTER_TESTNET_UPGRADE",
+        "height": "2123456",
         "info": "https://github.com/EpixZone/EpixChain/releases/tag/v0.5.3"
       }
     }


### PR DESCRIPTION
# Description
This pull request updates the upgrade proposal for version 0.5.3 by specifying the block height at which the upgrade should occur.

Upgrade proposal update:

* Set the upgrade `height` to `2123456` in `proposals/v0.5.3-upgrade-proposal.json`, replacing the placeholder value.
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the `main` branch
