### PR TITLE
Cache updatecache fix

### DIFF
--- a/evmd/app.go
+++ b/evmd/app.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	// Force-load the tracer engines to trigger registration due to Go-Ethereum v1.10.15 changes
 	"github.com/ethereum/go-ethereum/common"
@@ -259,16 +258,9 @@ func NewExampleApp(
 		evmtypes.StoreKey, feemarkettypes.StoreKey, erc20types.StoreKey, precisebanktypes.StoreKey, epixminttypes.StoreKey,
 	}
 
-	// Conditionally add TopHolders store key if enabled AND this is a fresh node
-	// For existing nodes, we'll run TopHolders in memory-only mode to avoid store version mismatch
+	// Conditionally add TopHolders store key if enabled
 	if topHoldersEnabled {
-		// Check if this is a fresh node by looking for existing database
-		dbPath := filepath.Join(cast.ToString(appOpts.Get(flags.FlagHome)), "data", "application.db")
-		if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-			// Fresh node - safe to add store key
-			storeKeys = append(storeKeys, topholderstypes.StoreKey)
-		}
-		// For existing nodes, we'll skip adding the store key and run in memory-only mode
+		storeKeys = append(storeKeys, topholderstypes.StoreKey)
 	}
 
 	keys := storetypes.NewKVStoreKeys(storeKeys...)
@@ -493,24 +485,10 @@ func NewExampleApp(
 	// Set up TopHolders keeper (only if enabled in config)
 	app.topHoldersEnabled = topHoldersEnabled
 	if topHoldersEnabled {
-		var storeKey storetypes.StoreKey
-		var memKey storetypes.StoreKey
-
-		// Check if store key exists (for new nodes) or use nil (for existing nodes)
-		if key, exists := keys[topholderstypes.StoreKey]; exists {
-			storeKey = key
-			memKey = key // Use same key for simplicity
-		} else {
-			// For backward compatibility with existing nodes, use nil store keys
-			storeKey = nil
-			memKey = nil
-			logger.Info("TopHolders module running in memory-only mode for backward compatibility")
-		}
-
 		app.TopHoldersKeeper = topholderskeeper.NewKeeper(
 			appCodec,
-			storeKey,
-			memKey,
+			keys[topholderstypes.StoreKey],
+			keys[topholderstypes.StoreKey],
 			authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 			app.BankKeeper,
 			app.StakingKeeper,

--- a/evmd/upgrades.go
+++ b/evmd/upgrades.go
@@ -131,14 +131,18 @@ func (app EVMD) RegisterUpgradeHandlers() {
 		panic(err)
 	}
 
-	// Handle v0.5.1, v0.5.2, and v0.5.3 upgrades
+	// Handle store upgrades for each version
 	if (upgradeInfo.Name == UpgradeName_v0_5_1 ||
 		upgradeInfo.Name == UpgradeName_v0_5_2 ||
 		upgradeInfo.Name == UpgradeName_v0_5_3 ||
 		upgradeInfo.Name == UpgradeName_v0_5_4) &&
 		!app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		added := []string{}
+		if app.topHoldersEnabled {
+			added = append(added, "topholders")
+		}
 		storeUpgrades := storetypes.StoreUpgrades{
-			Added: []string{},
+			Added: added,
 		}
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))

--- a/evmd/upgrades.go
+++ b/evmd/upgrades.go
@@ -137,15 +137,20 @@ func (app EVMD) RegisterUpgradeHandlers() {
 		upgradeInfo.Name == UpgradeName_v0_5_3 ||
 		upgradeInfo.Name == UpgradeName_v0_5_4) &&
 		!app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
-		added := []string{}
-		if app.topHoldersEnabled {
-			added = append(added, "topholders")
-		}
-		storeUpgrades := storetypes.StoreUpgrades{
-			Added: added,
-		}
+		storeUpgrades := storetypes.StoreUpgrades{}
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, &storeUpgrades))
+	}
+
+	// If topholders is enabled, ensure its store exists. This handles nodes that
+	// enable topholders after already passing the upgrade height — the store loader
+	// will add the missing store on the next startup without requiring a new upgrade.
+	if app.topHoldersEnabled {
+		app.SetStoreLoader(func(ms storetypes.CommitMultiStore) error {
+			return ms.LoadLatestVersionAndUpgrade(&storetypes.StoreUpgrades{
+				Added: []string{"topholders"},
+			})
+		})
 	}
 }
 

--- a/x/topholders/keeper/cache.go
+++ b/x/topholders/keeper/cache.go
@@ -199,7 +199,7 @@ func (k *Keeper) UpdateCache(ctx context.Context) error {
 	// Step 6: Create and store the cache
 	cache := types.NewTopHoldersCache(
 		holders,
-		time.Now().Unix(),
+		sdkCtx.BlockTime().Unix(),
 		sdkCtx.BlockHeight(),
 	)
 


### PR DESCRIPTION
This pull request simplifies the logic for enabling the TopHolders module and improves compatibility for nodes that enable the module after initial setup. It removes the distinction between fresh and existing nodes, ensuring the store key is always added when TopHolders is enabled, and updates the upgrade handler to automatically add the store if needed. Additionally, it fixes a timestamp issue in the TopHolders cache.

TopHolders module improvements:

* Simplified TopHolders store key logic: The conditional check for fresh vs. existing nodes is removed; the store key is always appended to `storeKeys` when TopHolders is enabled, making the initialization consistent and easier to maintain (`evmd/app.go`).
* Unified TopHolders keeper initialization: The keeper is now always initialized with the store key, removing unnecessary checks and supporting backward compatibility more cleanly (`evmd/app.go`).

Upgrade handling enhancements:

* Automatic TopHolders store addition: The upgrade handler now ensures the TopHolders store is added if the module is enabled, even for nodes that enable it after passing the upgrade height, simplifying operational complexity (`evmd/upgrades.go`).

Bug fix:

* Correct cache timestamp: The TopHolders cache now uses the block time from `sdkCtx` instead of the current system time, ensuring accurate and deterministic timestamps (`x/topholders/keeper/cache.go`).

Cleanup:

* Removed unused `filepath` import from `evmd/app.go`, reflecting the simplified initialization logic.