### PR TITLE
ci: fix daily Dependency Review failure on scheduled runs

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -18,6 +18,11 @@ jobs:
           check-latest: true
       - name: "Checkout Repository"
         uses: actions/checkout@v4
+        with:
+          # depth 2 so HEAD^ resolves on scheduled / dispatch runs where
+          # the dependency-review action diffs the latest commit against
+          # its parent (default depth=1 truncates history to one commit).
+          fetch-depth: 2
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
@@ -25,8 +30,25 @@ jobs:
             go.mod
             go.sum
             *.toml
-      - name: "Dependency Review"
+      # PR / merge_group events: the action auto-detects base/head from the
+      # event payload — leave it on its own. Scheduled / dispatch runs have
+      # no PR context, so resolve the latest commit's parent SHA and feed
+      # both refs explicitly so the action has something to diff.
+      - name: "Resolve base/head SHA for non-PR runs"
+        id: refs
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        run: |
+          echo "base=$(git rev-parse HEAD~1)" >> "$GITHUB_OUTPUT"
+          echo "head=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: "Dependency Review (PR / merge_group)"
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         uses: actions/dependency-review-action@v4
+      - name: "Dependency Review (scheduled / dispatch)"
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        uses: actions/dependency-review-action@v4
+        with:
+          base-ref: ${{ steps.refs.outputs.base }}
+          head-ref: ${{ steps.refs.outputs.head }}
       - name: "Get govulncheck"
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck


### PR DESCRIPTION
## Summary
- The Dependency Review workflow fails every day at 03:00 UTC because `actions/dependency-review-action@v4` has no `pull_request` / `merge_group` event payload to read base/head from on a scheduled run ([example failure](https://github.com/EpixZone/EpixChain/actions/runs/25716739730/job/75508272051)).
- Split the action invocation: keep auto-detection for PR / merge_group runs; for scheduled / dispatch runs, resolve `HEAD` and `HEAD~1` in a prior step and pass them explicitly as `base-ref` / `head-ref` so the action has a concrete diff range.
- Bump `actions/checkout` to `fetch-depth: 2` so `HEAD~1` actually resolves on the runner.

## Test plan
- [ ] Merge → wait for the next 03:00 UTC cron and confirm the run succeeds, OR trigger the workflow manually via `workflow_dispatch` and confirm both the "Dependency Review (scheduled / dispatch)" step and `govulncheck` run cleanly.
- [ ] Open / re-run a separate PR and confirm the "Dependency Review (PR / merge_group)" step still runs and the auto-detected refs are correct.