### PR TITLE
Clarify mempool type instructions in v0.7.0.md

### DIFF
--- a/docs/upgrades/v0.7.0.md
+++ b/docs/upgrades/v0.7.0.md
@@ -38,28 +38,22 @@ You can do this any time before the upgrade height. The change is forward-
 compatible: it only takes effect once the v0.7.0 binary is running, and the
 v0.5.5 binary keeps working with the new value.
 
-1. Stop the node:
+Edit `~/.epixd/config/config.toml`. Find the `[mempool]` section and change
+the `type` line:
 
-   ```bash
-   sudo systemctl stop epix.service     # or whatever your unit is called
-   ```
+```diff
+ [mempool]
+- type = "flood"
++ type = "app"
+```
 
-2. Edit `~/.epixd/config/config.toml`. Find the `[mempool]` section and change
-   the `type` line:
+Quick one-liner if you prefer:
 
-   ```diff
-    [mempool]
-   - type = "flood"
-   + type = "app"
-   ```
+```bash
+sed -i 's/^type = "flood"$/type = "app"/' ~/.epixd/config/config.toml
+```
 
-   Quick one-liner if you prefer:
-
-   ```bash
-   sed -i 's/^type = "flood"$/type = "app"/' ~/.epixd/config/config.toml
-   ```
-
-   Verify the change:
+Verify the change:
 
    ```bash
    grep -A1 '^\[mempool\]' ~/.epixd/config/config.toml | head -3
@@ -67,11 +61,7 @@ v0.5.5 binary keeps working with the new value.
 
    You should see `type = "app"`.
 
-3. Restart the node:
-
-   ```bash
-   sudo systemctl start epix.service
-   ```
+Do not restart the node otherwise it will crash and you'll need to set it back to `flood`, restart, and then follow these instructions again.
 
 ### At the upgrade height (recovery)
 


### PR DESCRIPTION
The instructions told you to restart your node before the upgrade window, but you should not do that. Added correct instructions and recovery steps in case you followed the old instructions.